### PR TITLE
Bump library versions for idea, sqldelight, sql-psi

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-idea = "221.6008.13"
+idea = "222.4459.24"
 kotlin = "1.8.22"
 ktlint = "0.49.1"
 spotless = "6.19.0"
-sqldelight = "2.0.0-rc01"
-sql-psi = "0.4.3"
+sqldelight = "2.0.0-rc02"
+sql-psi = "0.4.5"
 
 [libraries]
 intellij-analysis = { module = "com.jetbrains.intellij.platform:analysis-impl", version.ref = "idea" }


### PR DESCRIPTION
Keeping inline with https://github.com/cashapp/sqldelight/blob/master/gradle/libs.versions.toml