### PR TITLE
Support unnamed indices in the CREATE INDEX statement.

### DIFF
--- a/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
+++ b/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
@@ -91,10 +91,10 @@ string_data_type ::= ((( 'CHARACTER' 'VARYING' ) | 'VARCHAR' | 'CHARACTER' | 'CH
   override = true
 }
 
-create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ IF NOT EXISTS ] [ ansi_database_name DOT ] ansi_index_name ON ansi_table_name LP ansi_indexed_column ( COMMA ansi_indexed_column ) * RP ['STORING' LP ansi_indexed_column ( COMMA ansi_indexed_column ) * RP ] [ WHERE <<expr '-1'>> ] {
-  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlCreateIndexStmtImpl"
+create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ IF NOT EXISTS ] [ [ ansi_database_name DOT ] ansi_index_name ] ON ansi_table_name LP ansi_indexed_column ( COMMA ansi_indexed_column ) * RP ['STORING' LP ansi_indexed_column ( COMMA ansi_indexed_column ) * RP ] [ WHERE <<expr '-1'>> ] {
+  extends = "com.faire.sqldelight.dialects.cockroachdb.grammar.mixins.CreateIndexMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlCreateIndexStmt"
-  pin = 6
+  pin = 4
 }
 
 generated_clause ::= (postgres_generated_clause | cockroach_generated_clause) {

--- a/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/mixins/CreateIndexMixin.kt
+++ b/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/mixins/CreateIndexMixin.kt
@@ -1,0 +1,30 @@
+package com.faire.sqldelight.dialects.cockroachdb.grammar.mixins
+
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.Schema
+import com.alecstrong.sql.psi.core.psi.SqlCreateIndexStmt
+import com.alecstrong.sql.psi.core.psi.impl.SqlCreateIndexStmtImpl
+import com.intellij.lang.ASTNode
+
+internal abstract class CreateIndexMixin(
+  node: ASTNode?,
+) : SqlCreateIndexStmtImpl(node),
+  SqlCreateIndexStmt {
+  /**
+   * In CockroachDB, an index name doesn't have to be specified. For now try/catch and do nothing.
+   */
+  override fun modifySchema(schema: Schema) {
+    try {
+      super.modifySchema(schema)
+    } catch (e: AssertionError) {
+      // Hack to support unnamed indices.
+    }
+  }
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    try {
+      super.annotate(annotationHolder)
+    } catch (e: AssertionError) {
+      // Hack to support unnamed indices.
+    }
+  }
+}

--- a/cockroachdb-dialect/src/test/fixtures_cockroachdb/create-index-unnamed/1.s
+++ b/cockroachdb-dialect/src/test/fixtures_cockroachdb/create-index-unnamed/1.s
@@ -1,0 +1,9 @@
+CREATE TABLE foo(
+  id INT NOT NULL,
+  bar VARCHAR(255) NOT NULL,
+  token VARCHAR(25) NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX ON foo (bar);
+CREATE UNIQUE INDEX ON foo (token);


### PR DESCRIPTION
This includes a hack to just try/catch the exception when it tries to fetch the name.