### PR TITLE
Don't try/catch when tracking index names. Just noop instead.

### DIFF
--- a/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/mixins/CreateIndexMixin.kt
+++ b/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/mixins/CreateIndexMixin.kt
@@ -11,20 +11,12 @@ internal abstract class CreateIndexMixin(
 ) : SqlCreateIndexStmtImpl(node),
   SqlCreateIndexStmt {
   /**
-   * In CockroachDB, an index name doesn't have to be specified. For now try/catch and do nothing.
+   * In CockroachDB, an index name doesn't have to be specified. For now disable tracking the index.
    */
   override fun modifySchema(schema: Schema) {
-    try {
-      super.modifySchema(schema)
-    } catch (e: AssertionError) {
-      // Hack to support unnamed indices.
-    }
+    // Intentionally left blank.
   }
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
-    try {
-      super.annotate(annotationHolder)
-    } catch (e: AssertionError) {
-      // Hack to support unnamed indices.
-    }
+    // Intentionally left blank.
   }
 }

--- a/cockroachdb-dialect/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/CockroachDBFixturesTest.kt
+++ b/cockroachdb-dialect/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/CockroachDBFixturesTest.kt
@@ -45,6 +45,9 @@ class CockroachDBFixturesTest(name: String, fixtureRoot: File) : FixturesTest(na
 
     private val excludedAnsiFixtures = listOf(
       "index-migration", // Excluded since we're not validating indices when dropping them.
+      "create-table-validation-failures", // Excluded since we're not validating indices when creating them.
+      "create-if-not-exists", // Excluded since we're not validating indices when creating them.
+      "create-index-collision", // Excluded since we're not validating indices when creating them.
     )
 
     // Used by Parameterized JUnit runner reflectively.


### PR DESCRIPTION
There are error logs that gets raised on unnamed indices. Seems better to noop for now.