### PR TITLE
Integer type width changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ This doesn't fully cover the whole SQL syntax of CockroachDB. It's a work in pro
 * Supports unnamed index
   * Index tracking and validation has been disabled until there's a way to track unnamed indexes
 * Blob types (BYTEA, BLOB, BYTES)
+* [Integer types](https://www.cockroachlabs.com/docs/stable/int.html) (32bit and 64bit aliases)

--- a/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
+++ b/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
@@ -73,6 +73,8 @@
 }
 
 overrides ::= table_constraint
+  | int_data_type
+  | big_int_data_type
   | string_data_type
   | blob_data_type
   | generated_clause
@@ -85,6 +87,18 @@ table_constraint ::= [ CONSTRAINT ansi_identifier ] (
 ) {
   extends = "app.cash.sqldelight.dialects.postgresql.grammar.psi.impl.PostgreSqlTableConstraintImpl"
   implements = "app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableConstraint"
+  override = true
+}
+
+int_data_type ::= 'INT4' {
+  extends = "app.cash.sqldelight.dialects.postgresql.grammar.psi.impl.PostgreSqlIntDataTypeImpl"
+  implements = "app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlIntDataType"
+  override = true
+}
+
+big_int_data_type ::= 'INT' | 'INTEGER' | 'INT8' | 'INT64' | 'BIGINT' {
+  extends = "app.cash.sqldelight.dialects.postgresql.grammar.psi.impl.PostgreSqlBigIntDataTypeImpl"
+  implements = "app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlBigIntDataType"
   override = true
 }
 

--- a/cockroachdb-dialect/src/test/fixtures_cockroachdb/32bit-int-types/1.s
+++ b/cockroachdb-dialect/src/test/fixtures_cockroachdb/32bit-int-types/1.s
@@ -1,0 +1,5 @@
+CREATE TABLE foo(
+  id INT NOT NULL,
+  int4_col INT4 NOT NULL,
+  PRIMARY KEY(id)
+);

--- a/cockroachdb-dialect/src/test/fixtures_cockroachdb/64bit-int-types/1.s
+++ b/cockroachdb-dialect/src/test/fixtures_cockroachdb/64bit-int-types/1.s
@@ -1,0 +1,9 @@
+CREATE TABLE foo(
+  id INT NOT NULL,
+  int_col INT NOT NULL,
+  integer_col INTEGER NOT NULL,
+  int8_col INT8 NOT NULL,
+  int64_col INT64 NOT NULL,
+  bigint_col BIGINT NOT NULL,
+  PRIMARY KEY(id)
+);

--- a/integration-testing/src/main/resources/migrations/v202307111826__int_big_int.sqm
+++ b/integration-testing/src/main/resources/migrations/v202307111826__int_big_int.sqm
@@ -1,0 +1,10 @@
+CREATE TABLE int_big_int(
+  id INT NOT NULL,
+  int4_col INT4 NOT NULL,
+  int_col INT NOT NULL,
+  integer_col INTEGER NOT NULL,
+  int8_col INT8 NOT NULL,
+  int64_col INT64 NOT NULL,
+  bigint_col BIGINT NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/integration-testing/src/main/sqldelight/com/faire/sqldelight/dialects/cockroachdb/IntBigInt.sq
+++ b/integration-testing/src/main/sqldelight/com/faire/sqldelight/dialects/cockroachdb/IntBigInt.sq
@@ -1,0 +1,2 @@
+create:
+INSERT INTO int_big_int VALUES ?;

--- a/integration-testing/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/IntegrationTest.kt
+++ b/integration-testing/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/IntegrationTest.kt
@@ -2,6 +2,7 @@ package com.faire.sqldelight.dialects.cockroachdb
 
 import Blob_data_types
 import Computed_column
+import Int_big_int
 import String_type
 import app.cash.sqldelight.driver.jdbc.JdbcDriver
 import app.cash.sqldelight.driver.jdbc.asJdbcDriver
@@ -62,6 +63,21 @@ class IntegrationTest {
       assertThat(blob_col.toString(charset)).isEqualTo("bar")
       assertThat(bytes_col.toString(charset)).isEqualTo("baz")
     }
+  }
+
+  @Test
+  fun `integer types`() {
+    database.intBigIntQueries.create(
+      Int_big_int(
+        id = 1,
+        int4_col = 2,
+        int_col = 3L,
+        integer_col = 4L,
+        int8_col = 5L,
+        int64_col = 6L,
+        bigint_col = 7L,
+      ),
+    )
   }
 
   companion object {


### PR DESCRIPTION
Slight differences between cockroachdb and postgres where some postgres int types were converted from 32bit to 64bit.

Reference: https://www.cockroachlabs.com/docs/stable/int.html