### PR TITLE
Use implementation instead of api for sqldelight postgres dialect dep

### DIFF
--- a/cockroachdb-dialect/build.gradle.kts
+++ b/cockroachdb-dialect/build.gradle.kts
@@ -13,7 +13,7 @@ grammarKit {
 
 dependencies {
   compileOnly(libs.sqldelight.compiler.env)
-  api(libs.sqldelight.postgresql.dialect)
+  implementation(libs.sqldelight.postgresql.dialect)
 
   testImplementation(libs.intellij.analysis)
   testImplementation(libs.sql.psi.test.fixtures) {


### PR DESCRIPTION
Prepping for a release. Reducing exposed libraries to the end user.