### PR TITLE
Remove Ktor EAP repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ allprojects {
     exclude(group = "com.jetbrains.rd")
     exclude(group = "com.github.jetbrains", module = "jetCheck")
     exclude(group = "com.jetbrains.infra")
+    exclude(group = "com.jetbrains.intellij.platform", module = "wsl-impl")
 
     exclude(group = "org.roaringbitmap")
 
@@ -38,7 +39,6 @@ allprojects {
 
   repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/public/p/ktor/eap")
   }
 }
 


### PR DESCRIPTION
Turns out, we don't actually need this repo after excluding this module.

Taken from: https://github.com/cashapp/sqldelight/pull/4813