### PR TITLE
Remove buildLogic folder since libs.versions.toml is already being parsed by the project.

### DIFF
--- a/buildLogic/settings.gradle.kts
+++ b/buildLogic/settings.gradle.kts
@@ -1,9 +1,0 @@
-dependencyResolutionManagement {
-  versionCatalogs {
-    create("libs") {
-      from(files("../gradle/libs.versions.toml"))
-    }
-  }
-}
-
-rootProject.name = "buildLogic"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 rootProject.name = "sqldelight-cockroachdb-dialect"
 
-include("buildLogic")
 include("cockroachdb-dialect")
 include("integration-testing")
 


### PR DESCRIPTION
Simplify the setup 👍 👍 👍 