### PR TITLE
Ignore sql-psi releases in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - com.alecstrong.sql.psi:* # Needs to be coordinated with sqldelight release


### PR DESCRIPTION
Need to use the same version as sqldelight. Ignoring it in dependabot.