### PR TITLE
Fix COLLATE column_constraint

### DIFF
--- a/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
+++ b/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
@@ -14,6 +14,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.AS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.BY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CREATE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.COLLATE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COMMA"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONSTRAINT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DATABASE"

--- a/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/collate-column-constraint/1.s
+++ b/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/collate-column-constraint/1.s
@@ -1,0 +1,8 @@
+CREATE TABLE foo (
+  id INT NOT NULL,
+  bar VARCHAR(255) COLLATE en_US_u_ks_level2 NOT NULL,
+  PRIMARY KEY (id)
+);
+
+ALTER TABLE foo
+  ADD COLUMN baz VARCHAR(255) COLLATE en_US_u_ks_level2 NOT NULL;


### PR DESCRIPTION
Was getting this error for migration files contains COLLATE

```
java.lang.AssertionError: Test failed because the compile output unexpectedly has the errors <[
    1.s line 3:19 - ')', ',', <column constraint real> or '[]' expected, got 'COLLATE'
]>. 
```

Fix is to just import COLLATE.