### PR TITLE
Support DROP INDEX CASCADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-# Notice
-
-There's a regression from the Postgres Dialect (ALTER TABLE ALTER COLUMN) in SQLDelight 2.0.1 that prevents this dialect
-from working during the migration process. Please use `0.2.0` for the time being.
-
 # SQLDelight CockroachDB Dialect
 [CockroachDB](https://www.cockroachlabs.com/) dialect for [SQLDelight](https://github.com/cashapp/sqldelight).
 CockroachDB supports the majority of the PostgreSQL syntax (please see this [page](https://www.cockroachlabs.com/docs/stable/postgresql-compatibility.html) for more details).
+
+## Important notes
 
 ### Disclaimer
 This doesn't fully cover the whole SQL syntax of CockroachDB. It's a work in progress and contributions are welcome.
@@ -13,11 +10,11 @@ This doesn't fully cover the whole SQL syntax of CockroachDB. It's a work in pro
 ### Differences between the PostgreSQL SQLDelight Dialect
 * Supports ALTER PRIMARY KEY
 * Supports specifying an index in a CREATE TABLE statement
-* Supports DROP INDEX `<table>@<index_name>` syntax
+* Supports DROP INDEX [IF EXISTS] `<table>@<index_name>` [CASCADE]
 * Supports STRING data type
 * Supports storing index
 * Supports unnamed index
-  * Index tracking and validation has been disabled until there's a way to track unnamed indexes
+  * Index tracking and validation have been disabled until there's a way to track unnamed indexes
 * Blob types (BYTEA, BLOB, BYTES)
 * [Integer types](https://www.cockroachlabs.com/docs/stable/int.html) (32bit and 64bit aliases)
 * [Specify precision to TIMESTAMPTZ](https://www.cockroachlabs.com/docs/stable/timestamp.html#precision)
@@ -27,6 +24,8 @@ This doesn't fully cover the whole SQL syntax of CockroachDB. It's a work in pro
   * [Adding](https://www.cockroachlabs.com/docs/stable/alter-database#add-region)/[Dropping](https://www.cockroachlabs.com/docs/stable/alter-database#drop-region) regions
 * [Setting survival goal](https://www.cockroachlabs.com/docs/stable/alter-database#survive-zone-region-failure)
 
+## Usage
+
 ### Using this Library
 
 Please see the official [SQLDelight Documentation](https://cashapp.github.io/sqldelight/jvm_postgresql/#getting-started-with-postgresql).
@@ -34,7 +33,7 @@ Please see the official [SQLDelight Documentation](https://cashapp.github.io/sql
 To use this dialect, set the dialect to be:
 `dialect("com.faire:sqldelight-cockroachdb-dialect:<version>")`
 
-Latest version can be found [here](https://central.sonatype.com/artifact/com.faire/sqldelight-cockroachdb-dialect).
+The latest version can be found [here](https://central.sonatype.com/artifact/com.faire/sqldelight-cockroachdb-dialect).
 
 ### Using a Snapshot Release
 
@@ -63,3 +62,10 @@ Then access the `gradle.properties` file https://github.com/Faire/sqldelight-coc
 Given these two values, you should use `0.3.1-80dc790b417dedb12ae657b9112f0e6edfe4c5a1-SNAPSHOT` as the version in [the previous section](#using-this-library)
 
 [Here is a sample PR](https://github.com/Faire/sqldelight-cockroachdb-dialect/pull/101) that is using a snapshot release for the dialect.
+
+## Development
+
+This project uses very basic Gradle; importing it into IntelliJ should work out of the box.
+
+We use [testcontainers](https://java.testcontainers.org/) to run integration tests. Please refer to their documentation
+on [environment setup](https://java.testcontainers.org/supported_docker_environment/).

--- a/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
+++ b/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
@@ -13,6 +13,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ADD"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.AS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.BY"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.CASCADE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CREATE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COLLATE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COMMA"
@@ -185,7 +186,7 @@ private postgres_generated_clause ::= GENERATED ( (ALWAYS AS LP <<expr '-1'>> RP
 
 private cockroach_generated_clause ::= AS LP <<expr '-1'>> RP ('STORED' | 'VIRTUAL')
 
-drop_index_stmt ::= DROP INDEX [ IF EXISTS ] [ ansi_table_name '@' ] ansi_index_name {
+drop_index_stmt ::= DROP INDEX [ IF EXISTS ] [ ansi_table_name '@' ] ansi_index_name [ CASCADE ] {
   mixin = "com.faire.sqldelight.dialects.cockroachdb.grammar.mixins.DropIndexMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlDropIndexStmt"
   pin = 2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 idea = "231.9392.1"
-kotlin = "1.9.23"
+kotlin = "2.0.10"
 spotless = "6.25.0"
 sql-psi = "0.4.9"
 sqldelight = "2.0.2"
@@ -9,12 +9,13 @@ sqldelight = "2.0.2"
 assertj-core = { module = "org.assertj:assertj-core", version = "3.26.3" }
 intellij-analysis = { module = "com.jetbrains.intellij.platform:analysis-impl", version.ref = "idea" }
 postgres-jdbc-driver = { module = "org.postgresql:postgresql", version = "42.7.3" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version = "2.0.17" }
 sql-psi = { module = "com.alecstrong.sql.psi:core", version.ref = "sql-psi" }
 sql-psi-enviroment = { module = "com.alecstrong.sql.psi:environment", version.ref = "sql-psi" }
 sqldelight-compiler-env = { module = "app.cash.sqldelight:compiler-env", version.ref = "sqldelight" }
 sqldelight-jdbc-driver = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
 sqldelight-postgresql-dialect = { module = "app.cash.sqldelight:postgresql-dialect", version.ref = "sqldelight" }
-testcontainers-cockroachdb = { module = "org.testcontainers:cockroachdb", version = "1.20.1" }
+testcontainers-cockroachdb = { module = "org.testcontainers:cockroachdb", version = "1.21.0" }
 
 [plugins]
 grammar-kit-composer = { id = "com.alecstrong.grammar.kit.composer", version = "0.1.12" }

--- a/integration-testing/build.gradle.kts
+++ b/integration-testing/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
   api(libs.sqldelight.jdbc.driver)
 
+  testRuntimeOnly(libs.slf4j.simple)
+
   testImplementation(libs.assertj.core)
   testImplementation(libs.postgres.jdbc.driver)
   testImplementation(libs.testcontainers.cockroachdb)

--- a/integration-testing/src/main/resources/migration/com/faire/sqldelight/dialects/cockroachdb/v202307101516__drop_index.sqm
+++ b/integration-testing/src/main/resources/migration/com/faire/sqldelight/dialects/cockroachdb/v202307101516__drop_index.sqm
@@ -12,5 +12,13 @@ CREATE TABLE drop_index_two(
   INDEX idx_foo (foo)
 );
 
+CREATE TABLE drop_unique_index(
+  id INT NOT NULL,
+  uid INT NOT NULL,
+  PRIMARY KEY(id),
+  UNIQUE INDEX idx_uid (uid)
+);
+
 DROP INDEX drop_index_one@idx_foo;
-DROP INDEX drop_index_two@idx_foo;
+DROP INDEX IF EXISTS drop_index_two@idx_foo;
+DROP INDEX drop_unique_index@idx_uid CASCADE;


### PR DESCRIPTION
Add support for https://www.cockroachlabs.com/docs/v25.2/drop-index#remove-an-index-and-dependent-objects-with-cascade

See the integration test which would fail in the current head.

Drive-by:

* Bump Kotlin version
* Improve README (add mentions of test setup and fix typos)
* Improve test setup (set up slf4j logger and bump testcontainers)