### PR TITLE
Upgrade to sqldelight 2.1.0 and sql-psi 0.5.2

### DIFF
--- a/cockroachdb-dialect/build.gradle.kts
+++ b/cockroachdb-dialect/build.gradle.kts
@@ -22,8 +22,6 @@ dependencies {
   }
 
   testImplementation(libs.sqldelight.compiler.env)
-  // Remove with next sql-psi release https://github.com/AlecKazakova/sql-psi/pull/619
-  testImplementation(libs.sql.psi.enviroment)
   testFixturesApi(testFixtures(libs.sql.psi))
 }
 

--- a/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
+++ b/cockroachdb-dialect/src/main/kotlin/com/faire/sqldelight/dialects/cockroachdb/grammar/CockroachDB.bnf
@@ -1,5 +1,5 @@
 {
-  // Specify the parent parser.
+  // Specify the parent parser; our grammar hence must base on PostgreSql.bnf from sqldelight.
   overrides="app.cash.sqldelight.dialects.postgresql.grammar.PostgreSqlParser"
   elementTypeClass = "com.alecstrong.sql.psi.core.SqlElementType"
 
@@ -104,7 +104,8 @@ overrides ::= table_constraint
 index_using_hash ::= USING 'HASH' [ WITH LP 'bucket_count' EQ ansi_signed_number RP ]
 
 table_constraint ::= table_family_constraint | [ CONSTRAINT ansi_identifier ] (
-  ( PRIMARY KEY | [UNIQUE] INDEX | UNIQUE ) [ansi_index_name] LP ansi_indexed_column [ LP ansi_signed_number RP ] ( COMMA ansi_indexed_column [ LP ansi_signed_number RP ] ) * RP [ index_using_hash ] [('STORING' | 'COVERING' | 'INCLUDE') LP ansi_column_name ( COMMA ansi_column_name ) * RP ] [ WHERE <<expr '-1'>> ] ansi_conflict_clause [comment_type] |
+  ( PRIMARY KEY | [UNIQUE] INDEX | UNIQUE ) [ansi_index_name] LP ansi_indexed_column [ LP ansi_signed_number RP ] ( COMMA ansi_indexed_column [ LP ansi_signed_number RP ] ) * RP [ index_using_hash ] [('STORING' | 'COVERING' | 'INCLUDE') LP ansi_column_name ( COMMA ansi_column_name ) * RP ] [ WHERE <<expr '-1'>> ] [ansi_conflict_clause] [comment_type] |
+  'EXCLUDE' USING {index_method} LP <<expr '-1'>> WITH {constraint_exclude_operators} ( COMMA <<expr '-1'>> WITH {constraint_exclude_operators} ) * RP [ WHERE LP <<expr '-1'>> RP ] |
   ansi_check_constraint |
   FOREIGN KEY LP ansi_column_name ( COMMA ansi_column_name ) * RP ansi_foreign_key_clause
 ) {
@@ -116,9 +117,9 @@ table_constraint ::= table_family_constraint | [ CONSTRAINT ansi_identifier ] (
 table_family_constraint ::= 'FAMILY' [ ansi_identifier ] LP ansi_column_name ( COMMA ansi_column_name ) * RP
 
 column_constraint ::= alter_table_add_column_family_constraint | [ CONSTRAINT ansi_identifier ] (
-  PRIMARY KEY [ index_using_hash ] [ ASC | DESC ] ansi_conflict_clause |
-  [ NOT ] NULL ansi_conflict_clause |
-  UNIQUE ansi_conflict_clause |
+  PRIMARY KEY [ index_using_hash ] [ ASC | DESC ] [ansi_conflict_clause] |
+  [ NOT ] NULL [ansi_conflict_clause] |
+  UNIQUE [ansi_conflict_clause] |
   ansi_check_constraint |
   generated_clause |
   {default_constraint} |
@@ -169,8 +170,10 @@ blob_data_type ::= 'BYTEA' | 'BLOB' | 'BYTES' {
   override = true
 }
 
-create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ 'CONCURRENTLY' ] [ IF NOT EXISTS ] [ [ ansi_database_name DOT ] ansi_index_name ] ON ansi_table_name
-  ( USING 'GIN' LP ansi_indexed_column [ {gin_operator_class_stmt} ] ( COMMA ansi_indexed_column [ {gin_operator_class_stmt} ] ) * RP | LP ansi_indexed_column ( COMMA ansi_indexed_column ) * RP [ index_using_hash ] [('STORING' | 'COVERING' | 'INCLUDE') LP ansi_indexed_column ( COMMA ansi_indexed_column ) * RP ] [ WHERE <<expr '-1'>> ] ) {
+create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ 'CONCURRENTLY' ] [ IF NOT EXISTS ] [ [ ansi_database_name DOT ] ansi_index_name ] ON ansi_table_name (
+  USING {index_method} LP ansi_indexed_column [ {operator_class_stmt} ] ( COMMA ansi_indexed_column [ {operator_class_stmt} ] ) * RP [ {with_storage_parameter} ] |
+  LP ansi_indexed_column [ {operator_class_stmt} ] ( COMMA ansi_indexed_column [ {operator_class_stmt} ] ) * RP [ index_using_hash ] [ ('STORING' | 'COVERING' | 'INCLUDE') LP ansi_indexed_column ( COMMA ansi_indexed_column ) * RP ] [ WHERE <<expr '-1'>> ]
+) {
   extends = "com.faire.sqldelight.dialects.cockroachdb.grammar.mixins.CreateIndexMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlCreateIndexStmt"
   pin = 5
@@ -208,6 +211,7 @@ alter_table_rules ::= (
   ansi_alter_table_add_column
   | ansi_alter_table_rename_table
   | {alter_table_rename_column}
+  | {alter_table_drop_constraint}
   | {alter_table_drop_column}
   | {alter_table_add_constraint}
   | alter_table_alter_primary_key

--- a/cockroachdb-dialect/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/CockroachDBFixturesTest.kt
+++ b/cockroachdb-dialect/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/CockroachDBFixturesTest.kt
@@ -24,6 +24,7 @@ import java.io.File
 @RunWith(Parameterized::class)
 class CockroachDBFixturesTest(name: String, fixtureRoot: File) : FixturesTest(name, fixtureRoot) {
   override val replaceRules = arrayOf(
+    // TODO: document why
     "INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT" to "SERIAL NOT NULL PRIMARY KEY",
     "AUTOINCREMENT" to "",
     "?1" to "?",
@@ -48,6 +49,15 @@ class CockroachDBFixturesTest(name: String, fixtureRoot: File) : FixturesTest(na
       "create-if-not-exists",
       // Excluded since we're not validating indices when creating them.
       "create-index-collision",
+      // Excluded since our error message is different;
+      // we've copied the test case, but without the failure case, into `multiple-column-where-ansi`.
+      "multiple-column-where"
+    )
+
+    private val excludedPgSqlFixtures = listOf(
+      // Excluded since we're not validating indices when creating them;
+      // we've copied the test case, but without error assertions, into `create-index-pgsql`.
+      "create-index",
     )
 
     // Used by Parameterized JUnit runner reflectively.
@@ -57,9 +67,10 @@ class CockroachDBFixturesTest(name: String, fixtureRoot: File) : FixturesTest(na
       val extraAnsiFixtures = ansiFixtures
         .filter { (it[0] as String) !in excludedAnsiFixtures }
 
-      return CockroachDBTestFixtures.fixtures +
-        PostgresqlTestFixtures.fixtures +
-        extraAnsiFixtures
+      val extraPgSqlFixtures = PostgresqlTestFixtures.fixtures
+        .filter { (it[0] as String) !in excludedPgSqlFixtures }
+
+      return CockroachDBTestFixtures.fixtures + extraPgSqlFixtures + extraAnsiFixtures
     }
   }
 }

--- a/cockroachdb-dialect/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/CockroachDBFixturesTest.kt
+++ b/cockroachdb-dialect/src/test/kotlin/com/faire/sqldelight/dialects/cockroachdb/CockroachDBFixturesTest.kt
@@ -51,7 +51,7 @@ class CockroachDBFixturesTest(name: String, fixtureRoot: File) : FixturesTest(na
       "create-index-collision",
       // Excluded since our error message is different;
       // we've copied the test case, but without the failure case, into `multiple-column-where-ansi`.
-      "multiple-column-where"
+      "multiple-column-where",
     )
 
     private val excludedPgSqlFixtures = listOf(

--- a/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/create-index-pgsql/1.s
+++ b/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/create-index-pgsql/1.s
@@ -1,0 +1,55 @@
+CREATE TABLE abg (
+    id INTEGER PRIMARY KEY,
+    alpha TEXT,
+    beta TEXT,
+    gamma TEXT
+);
+
+CREATE INDEX CONCURRENTLY beta_gamma_idx ON abg (beta, gamma);
+
+CREATE INDEX gamma_index_name ON abg (gamma) WHERE beta = 'some_value';
+
+CREATE INDEX alpha_index_name ON abg USING BTREE (alpha) WITH (fillfactor = 70, deduplicate_items = on);
+
+CREATE INDEX beta_gamma_index_name ON abg USING HASH (beta) WITH (fillfactor = 20);
+CREATE INDEX alpha_index_name_err ON abg USING BTREE (alpha) WITH (deduplicate_items = yes);
+CREATE INDEX beta_gamma_index_name_err ON abg USING HASH (beta) WITH (fillfactor = 1);
+CREATE INDEX beta_gamma_index_name_err_param ON abg USING HASH (beta) WITH (autosummarize = off);
+
+CREATE TABLE json_gin(
+  alpha JSONB,
+  beta JSONB
+);
+
+CREATE TABLE json_gist(
+  alpha JSONB,
+  beta JSONB
+);
+
+CREATE TABLE text_search(
+  alpha TSVECTOR,
+  beta TEXT
+);
+
+CREATE INDEX gin_alpha_1 ON json_gin USING GIN (alpha);
+CREATE INDEX gin_alpha_beta_2 ON json_gin USING GIN (alpha, beta);
+CREATE INDEX gin_alpha_beta_3 ON json_gin USING GIN (alpha jsonb_ops, beta);
+CREATE INDEX gin_alpha_beta_4 ON json_gin USING GIN (alpha, beta jsonb_path_ops) WITH (fastupdate = off);
+CREATE INDEX gin_alpha_beta_5 ON json_gin USING GIN (alpha jsonb_path_ops, beta jsonb_ops) WITH (gin_pending_list_limit = 2048);
+
+CREATE INDEX gist_alpha_1 ON text_search USING GIST (alpha) WITH (fillfactor = 75);
+CREATE INDEX gist_alpha_2 ON text_search USING GIST (alpha) WITH (buffering = on);
+
+CREATE INDEX tsv_gist_alpha_1 ON text_search USING GIST (alpha);
+CREATE INDEX tsv_gin_alpha_1 ON text_search USING GIN (alpha);
+CREATE INDEX trgm_gist_beta_1 ON text_search USING GIST (beta gist_trgm_ops(siglen=32));
+CREATE INDEX trgm_gist_beta_2 ON text_search USING GIN (beta gin_trgm_ops);
+
+CREATE INDEX beta_index ON text_search (beta varchar_pattern_ops);
+
+CREATE INDEX ts_brin_beta_1 ON text_search USING BRIN (beta) WITH (autosummarize = on, pages_per_range = 6);
+
+CREATE INDEX gin_alpha_beta_error_1 ON json_gin USING GIN (alpha jsonb_path_ops, beta jsonb_ops) WITH (gin_pending_list_limit = 1);
+CREATE INDEX gin_alpha_beta_error_2 ON json_gin USING GIN (alpha, beta jsonb_path_ops) WITH (fastupdate = yes);
+CREATE INDEX ts_brin_beta_error_1 ON text_search USING BRIN (beta) WITH (pages_per_range = 0);
+CREATE INDEX ts_brin_beta_error_2 ON text_search USING BRIN (beta) WITH (autosummarize=no);

--- a/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/drop-index-cascade/1.s
+++ b/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/drop-index-cascade/1.s
@@ -1,0 +1,9 @@
+CREATE TABLE drop_unique_index(
+  id INT NOT NULL,
+  uid INT NOT NULL,
+  PRIMARY KEY(id),
+  UNIQUE INDEX idx_uid (uid)
+);
+
+DROP INDEX drop_unique_index@idx_uid CASCADE;
+DROP INDEX IF EXISTS drop_unique_index@idx_uid CASCADE;

--- a/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/multiple-column-where-ansi/1.s
+++ b/cockroachdb-dialect/src/testFixtures/resources/fixtures_cockroachdb/multiple-column-where-ansi/1.s
@@ -1,0 +1,12 @@
+CREATE TABLE posts (
+  id TEXT NOT NULL PRIMARY KEY,
+  text TEXT,
+  created_at INTEGER NOT NULL
+);
+
+-- works fine.
+SELECT *
+FROM posts
+WHERE (id, created_at) <= (?, ?)
+ORDER BY created_at DESC
+LIMIT 4;

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 
 GROUP=com.faire
 POM_ARTIFACT_ID=sqldelight-cockroachdb-dialect
-VERSION_NAME=0.5.0
+VERSION_NAME=0.6.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,16 +2,15 @@
 idea = "231.9392.1"
 kotlin = "2.0.10"
 spotless = "7.0.3"
-sql-psi = "0.4.9"
-sqldelight = "2.0.2"
+sql-psi = "0.5.2"
+sqldelight = "2.1.0"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version = "3.27.3" }
 intellij-analysis = { module = "com.jetbrains.intellij.platform:analysis-impl", version.ref = "idea" }
 postgres-jdbc-driver = { module = "org.postgresql:postgresql", version = "42.7.5" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version = "2.0.17" }
-sql-psi = { module = "com.alecstrong.sql.psi:core", version.ref = "sql-psi" }
-sql-psi-enviroment = { module = "com.alecstrong.sql.psi:environment", version.ref = "sql-psi" }
+sql-psi = { module = "app.cash.sql-psi:core", version.ref = "sql-psi" }
 sqldelight-compiler-env = { module = "app.cash.sqldelight:compiler-env", version.ref = "sqldelight" }
 sqldelight-jdbc-driver = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
 sqldelight-postgresql-dialect = { module = "app.cash.sqldelight:postgresql-dialect", version.ref = "sqldelight" }


### PR DESCRIPTION
Unfortunately sql-psi 0.4.9 and sqldelight 2.0.2 have some regressions. sqldelight 2.1.0 and sql-psi 0.5.2 supposedly fix them. Some heavy rebasing of our forked BNF grammar was required in this process, but we have pretty solid test suites (I also added more test cases) so I'm relatively confident.

This also marks our 0.6 release.